### PR TITLE
Implemented fix for duplicate ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Peter Delevoryas
 # Open Issues/Bugs
 * Issue: very little error checking between processes
 * Issue: if two servers are running on the same port, client does not indicate there is an issue
+	-Fix: Added a vector to keep track of the ports that are currently in use and then compare the new port being created to the vector of ports to make sure it hasn't been used previously. Outputs error message if found to already be in use. One problem with my fix might be that it never removes the ports from the vector, so if one was deleted it would not remove the port from the vector. -elst0547
 * Issue: Windows support
 * If You have a bug to submit, add it to this portion of the README, and submit a pull request!
 

--- a/server_driver.cc
+++ b/server_driver.cc
@@ -3,6 +3,7 @@
 #include <iostream>
 
 server_session *ssn; // Must be declared globally for signal handler to work
+std::vector<String> ports; //Must be global in order to keep track of all ports for all servers.
 
 // Handles kill signal, ensuring that the server sessions's table destructor is called
 // This is important, as otherwise the binary file will not be written before the program
@@ -20,12 +21,26 @@ int main(int argc, char **argv)
     exit(1);
   }
 
+  bool check = false; //Needed for comparison in port duplication error checking
   static struct sigaction _sigact;
   signal(SIGINT, ExitHandler); // SIGINT = CTRL-C
   signal(SIGTERM, ExitHandler); // SIGTERM = kill pid
   std::cout << "Server session being created..." << std::endl;
-  ssn = new server_session(argv[1]); // Make a new server session with specified port from command line arg
+  String port = argv[1]; //Saves the command line argument for port number to a variable
+  if(ports.size() > 0) //Checks if list of currently used ports is empty or not
+  {
+    for(int i = 0; i < ports.size(); i++) //Used to check if port is in list of currently used ports
+    {
+      if(ports.get(i) == port)
+      {
+        cout<<"There is another server already using the same port. This may cause problems during use."<<endl;
+        check = true;
+      }
+    }
+  }
+  ssn = new server_session(port); // Make a new server session with specified port from command line arg
   if (ssn->is_valid()) { // if valid, initiate the client handling process
+    ports.push_back(port); //Adds the port to the list of currently used ports after sucessful creation of the server
     std::cout << "Server session created successfully, accepting clients..." << std::endl;
     ssn->init_chat();
   } else { // else, write error message, delete object, exit program


### PR DESCRIPTION
I added a fix to check if there is already a port running with a certain port number when a new one is created to make sure there aren't duplicate port numbers for different servers. Explanation in the README.md file.